### PR TITLE
validation is failed if instance type is descendant of one of applicable...

### DIFF
--- a/lib/jschema/simple_validator.rb
+++ b/lib/jschema/simple_validator.rb
@@ -28,7 +28,7 @@ module JSchema
     end
 
     def validate(instance)
-      if !applicable_types || applicable_types.include?(instance.class)
+      if !applicable_types || is_type_applicable?(instance.class)
         validate_instance(instance)
       end
     end
@@ -81,6 +81,10 @@ module JSchema
       schema.is_a?(Hash) && Schema.build(schema, parent, id)
     rescue InvalidSchema
       false
+    end
+
+    def is_type_applicable?(type)
+      applicable_types.any? { |t| type.ancestors.include? t }
     end
   end
 end

--- a/test/validator/test_simple_validator.rb
+++ b/test/validator/test_simple_validator.rb
@@ -82,6 +82,12 @@ class TestSimpleValidator < Minitest::Test
     end
   end
 
+  def test_applicable_types_for_descendants
+    stub_validator [Hash], false do |vdr|
+      refute vdr.valid?(Class.new(Hash).new)
+    end
+  end
+
   private
 
   def stub_validator(applicable_types, valid)


### PR DESCRIPTION
'Required' validation is skipped for ActionController::Parameters, because type checking for applicable_types  uses strict equality with type Hash, descendants are ignored. 
