### PR TITLE
Fix date requirement

### DIFF
--- a/lib/jschema/validator/format.rb
+++ b/lib/jschema/validator/format.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'ipaddr'
 
 module JSchema


### PR DESCRIPTION
Probably some of the dev dependencies require `date` so it all works. But
I had a project that didn't include date so then the validations were
failing.

I now added `date` in the format class file where `DateTime` is used which fixes
the issue.